### PR TITLE
Add ability to retrieve multiple vectors with a list of ids

### DIFF
--- a/SRP/SRP_files.py
+++ b/SRP/SRP_files.py
@@ -4,6 +4,7 @@ import sys
 import numpy as np
 import warnings
 import os
+import collections
 
 if sys.version_info[0] == 3:
     (py2, py3) = False, True
@@ -381,9 +382,25 @@ class Vector_file(object):
 
     def __getitem__(self, label):
         self._build_offset_lookup()
-        needed_position = self._offset_lookup[label]
-        self.file.seek(needed_position)
-        return self._read_binary_row()
+        
+        if isinstance(label, collections.MutableSequence):
+            is_iterable = True
+        else:
+            is_iterable = False
+            label = [label]
+
+        vecs = []
+        # Will fail on any missing labels
+        for l in label:
+            needed_position = self._offset_lookup[l]
+            self.file.seek(needed_position)
+            vec = self._read_binary_row()
+            vecs.append(vec)
+    
+        if is_iterable:
+            return np.stack(vecs)
+        else:
+            return vecs[0]
 
     def _read_binary_row(self):
         binary_len = self.precision * self.vector_size

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(name='SRP',
       packages=["SRP"],
-      version='1.0.0',
+      version='1.1.0',
       description="Run stable random projections.",
       long_description = open("README.rst").readlines(),
       url="http://github.com/bmschmidt/SRP",

--- a/tests/test.py
+++ b/tests/test.py
@@ -48,13 +48,24 @@ class ReadAndWrite(unittest.TestCase):
         foo = SRP.Vector_file("test.bin",mode="r")
         self.assertTrue(foo.vocab_size==4)
 
+        # Test Iteration
         read_in_values = dict()
         for (i,(name,array)) in enumerate(foo):
             read_in_values[name] = array
             (comp_name,comp_array) = self.test_set[i]
             self.assertEqual(comp_name,name)
             self.assertEqual(array.tolist(),comp_array.tolist())
-            
+        
+        # Individual Vec Getter
+        keys = [i for i, a in self.test_set]
+        for i, key in enumerate(keys):
+            vec = foo[key]
+            np.testing.assert_array_almost_equal(vec, self.test_set[i][1])
+        
+        # List Vec Getter
+        vecs = foo[keys]
+        self.assertEqual(vecs.shape, (len(keys), foo.dims))
+        
         foo.close()
         
         self.assertEqual(read_in_values["foo"].tolist(),read_in_values["foo2"].tolist())


### PR DESCRIPTION
I added the ability to retrieve lists of items. 

`vecf['uc1.$b317658-0001'] # Returns 1d array of shape (dim, )` 
`vecf[['uc1.$b317658-0001']] # Returns 2d array of shape (1, dim)` 
`vecf[['uc1.$b317658-0001', 'uc1.$b317658-0002']] # Returns 2d array of shape (2, dim)` 

Tests included.